### PR TITLE
Add repository key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src/ -d dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ndelitski/rancher-alarms.git"
+  },
   "author": "Nick Delitski",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Fixes `npm WARN rancher-alarms@0.1.1 No repository field.`
