### PR TITLE
feature/#12 build alarms image with alpine-node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM node:4.2.1-onbuild
+FROM ndelitski/node:4-onbuild

--- a/Dockerfile.alpine-node-onbuild
+++ b/Dockerfile.alpine-node-onbuild
@@ -1,0 +1,11 @@
+FROM mhart/alpine-node:4
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY package.json /usr/src/app/
+ONBUILD RUN npm install
+ONBUILD COPY . /usr/src/app
+
+CMD [ "npm", "start" ]
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run \
     ndelitski/rancher-alarms:0.1.0
 ```
 
-### Docker compose
+### Docker compose for mail notification target
 
 ```yml
 rancher-alarms:
@@ -38,6 +38,21 @@ rancher-alarms:
   tty: true
 ```
 
+### Docker compose for slack channel notification target
+
+```yml
+rancher-alarms:
+  image: ndelitski/rancher-alarms:0.1.0
+  environment:
+    RANCHER_ADDRESS: rancher.yourdomain.com[:port]
+    RANCHER_ACCESS_KEY: AccessKEY
+    RANCHER_SECRET_KEY: SECRETkey
+    RANCHER_PROJECT_ID: 1a5
+    ALARM_SLACK_WEBHOOK_URL: https://hooks.slack.com/services/YOUR_SLACK_UUID
+    ALARM_SLACK_CHANNEL: #devops
+    ALARM_SLACK_BOTNAME: rancher-alarm
+  tty: true
+```
 ## How it works
 
 On startup get a list of services and instantiate healthcheck monitor for each of them if service is in a running state. Removed, purged and etc services will be ignored
@@ -104,6 +119,11 @@ When a service transitions to a degraded state, all targets will be invoked to p
                 "host": "smtp.gmail.com",
                 "secureConnection": true,
                 "port": 465
+            },
+        "slack": {
+            "webhookUrl": "https://hooks.slack.com/services/YOUR_SLACK_UUID,
+            "botName": "rancher-alarm",
+            "channel": "#devops"
             }
         }
     }
@@ -128,6 +148,7 @@ When a service transitions to a degraded state, all targets will be invoked to p
 
 ### Supported notification targets
  - email
+ - slack
 
 ## Roadmap
  - Simplify configuration.
@@ -138,3 +159,4 @@ When a service transitions to a degraded state, all targets will be invoked to p
  - Test coverage. Setup drone.io
  - Notify when all services operate normal after some of them were in a degraded state
  - Refactor notifications
+ - Shrinking image size with alpine linux


### PR DESCRIPTION
- build onbuild base image with alpine-node (mhart/alpine-node:4) 
  . You need build and push it to hub.docker.com into your own account with tag of `ndelitski/node:4-onbuild`

```
docker build -t node:4-onbuild -f Dockerfile.alpine-node-onbuild .
docker tag node:4-onbuild ndelitski/node:4-onbuild
docker push ndelitski/node:4-onbuild
```
- build rancher-alarms image from new created alpine node onbuild image (#12) and reduce the image from 640MB to 64.17MB.
- update README for new slack notification target.
