### PR TITLE
Fixed retrieval of project id (environment id)

### DIFF
--- a/src/rancher.es6
+++ b/src/rancher.es6
@@ -28,9 +28,10 @@ export default class RancherClient {
   }
 
   async getCurrentProjectIdAsync() {
-    return (await this._request({
-      url: `/accounts`
-    })).data[0].id;
+    var test = (await this._request({
+      url: `/v1/projects/`
+    }))
+    return test.data[0].id;
   }
 
   async _request(options) {

--- a/src/rancher.es6
+++ b/src/rancher.es6
@@ -28,10 +28,9 @@ export default class RancherClient {
   }
 
   async getCurrentProjectIdAsync() {
-    var test = (await this._request({
+    return (await this._request({
       url: `/v1/projects/`
-    }))
-    return test.data[0].id;
+    })).data[0].id;
   }
 
   async _request(options) {


### PR DESCRIPTION
I wasn't able to run this as an agent because it tried to call http://rancherurl/accounts which will never work. When I changed /account to /v1/projects/ it worked because it retrieved correct projectId. I haven't tested this without using the image as an agent ( internal envs for CATTLE_URL etc )
